### PR TITLE
Add option to run user plugin

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -218,6 +218,11 @@ def outerInnerCompare(chain, oEntry, outer, inner, innerEvent, chainI, kargs):
 
     if outer["unpack"]:
         compare.compare(**kargs)
+        if kargs["plugin"]:
+             sys.path.append("plugins")
+             exec("import %s" % kargs["plugin"])
+             f = eval("%s.%s" % (kargs["plugin"], kargs["plugin"]))
+             f(**kargs)
 
 
 def loop(chain=None, chainI=None, outer={}, inner={}, innerEvent={}, options={}):

--- a/compare.py
+++ b/compare.py
@@ -648,7 +648,7 @@ def histogram_nMatched(book, matched=None, misMatched=None, nonMatched=None, tMa
                   title="TPs;number mis-matched;Events / bin")
 
 
-def compare(raw1={}, raw2={}, book=None, anyEmap=False,  printEmap=False, printMismatches=False, warnQuality=True, fewerHistos=False):
+def compare(raw1={}, raw2={}, book=None, anyEmap=False,  printEmap=False, printMismatches=False, warnQuality=True, fewerHistos=False, plugin=""): # last argument is a hack, FIXME
     doDump = (1 <= raw1[None]["dump"]) or raw1[None]["patterns"]
 
     if raw2 and anyEmap:

--- a/oneRun.py
+++ b/oneRun.py
@@ -47,7 +47,7 @@ def check_and_adjust(options):
 def go(options):
     kargs = subset(options, ["feds1", "feds2"], process=True)
     kargs.update(subset(options, ["nEvents", "nEventsSkip", "outputFile", "noUnpack", "patterns", "sparseLoop"]))
-    kargs["compareOptions"] = subset(options, ["anyEmap", "printEmap", "printMismatches", "fewerHistos"])
+    kargs["compareOptions"] = subset(options, ["anyEmap", "printEmap", "printMismatches", "fewerHistos", "plugin"])
     kargs["mapOptions"] = subset(options, ["printEventMap", "identityMap"])
     kargs["printOptions"] = subset(options, ["dump", "progress"])
     kargs["printOptions"].update(subset(options, ["noWarnUnpack", "noWarnQuality"], invert=True))

--- a/options.py
+++ b/options.py
@@ -73,6 +73,11 @@ def opts(alsoArgs=False):
                       default=False,
                       action="store_true",
                       help="Profile this program.")
+    common.add_option("--plugin",
+                      dest="plugin",
+                      type="str",
+                      default="",
+                      help="Run user plugin. E.g. if called with --plugin=blah, will call function named blah from plugins/blah.py")
     parser.add_option_group(common)
 
     printing = optparse.OptionGroup(parser, "Options for printing to stdout")

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,0 +1,4 @@
+gnore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,4 +1,4 @@
-gnore everything in this directory
+#ignore everything in this directory
 *
 # Except this file
 !.gitignore


### PR DESCRIPTION
Following your recipe, I added the "user plugin" feature. I added the plugin name option to the compare options, since it seemed like the easiest place for it to go, so that required the compare.compare definition to also take a plugin option, which is kind of ugly. I'd be happy to change it if you have a better way to do it -- let me know