### PR TITLE
look for FNAL runs, handle run numbers less than 100000 for them

### DIFF
--- a/configuration/sw.py
+++ b/configuration/sw.py
@@ -6,12 +6,16 @@ def files_this_machine(run, nCyclesMax=1):
     out = []
     for stem in ["data/USC_",
                  "data/run",
+                 "data/FNAL_",
                  "/tmp/USC_",
                  "data/B904_Integration_0000",
                  "/localdata/B904_Integration_",
                  "/localdata/B904_Integration_10000"]:
         for iCycle in range(nCyclesMax):
-            filename = stem + "%d" % run
+            if "FNAL" in stem:
+                filename = stem + "%06d" % run  # FNAL runs might be less than 100000
+            else:
+                filename = stem + "%d" % run
             if iCycle:
                 filename += ".%d" % iCycle
             filename += ".root"


### PR DESCRIPTION
This will make it easier for FNALers to use look.py. I added a janky method to handle FNAL run numbers, which are usually small numbers like e.g: 000042